### PR TITLE
[🎨Design] 영수증 조회 프론트 페이지 추가

### DIFF
--- a/src/components/payment/ReceiptDetail.tsx
+++ b/src/components/payment/ReceiptDetail.tsx
@@ -1,0 +1,157 @@
+import React, {useState, useEffect} from 'react';
+import {useParams} from 'react-router-dom';
+import {Receipt} from '../../types/receipt';
+import {Table, TableBody, TableCell, TableRow, Paper, Typography} from '@mui/material';
+import styled from 'styled-components';
+import {formatPrice} from "../../util/formatPrice.ts";
+
+const StyledPaper = styled(Paper)`
+  padding: 20px;
+  margin: 20px 0;
+`;
+
+const Title = styled(Typography)`
+  margin-bottom: 20px;
+`;
+
+
+const ReceiptDetail: React.FC = () => {
+    const {articleApiId, orderApiId, receiptApiId} = useParams<{
+        articleApiId: string,
+        orderApiId: string,
+        receiptApiId: string
+    }>();
+    const [receipt, setReceipt] = useState<Receipt | null>(null);
+
+    useEffect(() => {
+        const fetchReceiptDetail = async () => {
+            const response = await fetch(
+                `${import.meta.env.VITE_API}api/articles/${articleApiId}/order/${orderApiId}/${receiptApiId}`
+            );
+            if (response.ok) {
+                const data = await response.json();
+                setReceipt(data);
+            } else {
+                console.error('Failed to fetch receipt details');
+            }
+        };
+
+        fetchReceiptDetail();
+    }, [articleApiId, orderApiId, receiptApiId]);
+
+    if (!receipt) {
+        return <Typography>Loading...</Typography>;
+    }
+
+    return (
+        <StyledPaper elevation={3}>
+            <Title variant="h5">Receipt Details</Title>
+            <Table>
+                <TableBody>
+                    <TableRow>
+                        <TableCell>가맹점 ID</TableCell>
+                        <TableCell>{receipt.mid}</TableCell>
+                    </TableRow>
+                    <TableRow>
+                        <TableCell>API 버전</TableCell>
+                        <TableCell>{receipt.version}</TableCell>
+                    </TableRow>
+                    <TableRow>
+                        <TableCell>주문 이름</TableCell>
+                        <TableCell>{receipt.orderName}</TableCell>
+                    </TableRow>
+                    <TableRow>
+                        <TableCell>화폐 단위</TableCell>
+                        <TableCell>{receipt.currency}</TableCell>
+                    </TableRow>
+                    <TableRow>
+                        <TableCell>결제 방식</TableCell>
+                        <TableCell>{receipt.method}</TableCell>
+                    </TableRow>
+                    <TableRow>
+                        <TableCell>총 결제 금액</TableCell>
+                        <TableCell>{formatPrice(receipt.totalAmount)}</TableCell>
+                    </TableRow>
+                    <TableRow>
+                        <TableCell>잔액</TableCell>
+                        <TableCell>{formatPrice(receipt.balanceAmount)}</TableCell>
+                    </TableRow>
+                    <TableRow>
+                        <TableCell>공급 가격</TableCell>
+                        <TableCell>{formatPrice(receipt.suppliedAmount)}</TableCell>
+                    </TableRow>
+                    <TableRow>
+                        <TableCell>부가세</TableCell>
+                        <TableCell>{formatPrice(receipt.vat)}</TableCell>
+                    </TableRow>
+                    <TableRow>
+                        <TableCell>결제 상태</TableCell>
+                        <TableCell>{receipt.status}</TableCell>
+                    </TableRow>
+                    <TableRow>
+                        <TableCell>결제 요청 시각</TableCell>
+                        <TableCell>{receipt.requestedAt}</TableCell>
+                    </TableRow>
+                    <TableRow>
+                        <TableCell>결제 승인 시각</TableCell>
+                        <TableCell>{receipt.approvedAt}</TableCell>
+                    </TableRow>
+                    <TableRow>
+                        <TableCell>에스크로 사용 여부</TableCell>
+                        <TableCell>{receipt.useEscrow}</TableCell>
+                    </TableRow>
+                    <TableRow>
+                        <TableCell>문화비 지출 여부</TableCell>
+                        <TableCell>{receipt.cultureExpense}</TableCell>
+                    </TableRow>
+                    <TableRow>
+                        <TableCell>결제 유형</TableCell>
+                        <TableCell>{receipt.type}</TableCell>
+                    </TableRow>
+                    <TableRow>
+                        <TableCell>카드 회사명</TableCell>
+                        <TableCell>{receipt.card?.company}</TableCell>
+                    </TableRow>
+                    <TableRow>
+                        <TableCell>카드번호</TableCell>
+                        <TableCell>{receipt.card?.number}</TableCell>
+                    </TableRow>
+                    <TableRow>
+                        <TableCell>할부 개월</TableCell>
+                        <TableCell>{receipt.card?.installmentPlanMonths}</TableCell>
+                    </TableRow>
+                    <TableRow>
+                        <TableCell>무이자 여부</TableCell>
+                        <TableCell>{receipt.card?.isInterestFree}</TableCell>
+                    </TableRow>
+                    <TableRow>
+                        <TableCell>승인번호</TableCell>
+                        <TableCell>{receipt.card?.approveNo}</TableCell>
+                    </TableRow>
+                    <TableRow>
+                        <TableCell>카드 포인트 사용 여부</TableCell>
+                        <TableCell>{receipt.card?.useCardPoint}</TableCell>
+                    </TableRow>
+                    <TableRow>
+                        <TableCell>카드 타입</TableCell>
+                        <TableCell>{receipt.card?.cardType}</TableCell>
+                    </TableRow>
+                    <TableRow>
+                        <TableCell>소유자 타입</TableCell>
+                        <TableCell>{receipt.card?.ownerType}</TableCell>
+                    </TableRow>
+                    <TableRow>
+                        <TableCell>승인 상태</TableCell>
+                        <TableCell>{receipt.card?.acquireStatus}</TableCell>
+                    </TableRow>
+                    <TableRow>
+                        <TableCell>영수증 URL</TableCell>
+                        <TableCell><a href={receipt.card?.receiptUrl} target="_blank" rel="noopener noreferrer">영수증 보기</a></TableCell>
+                    </TableRow>
+                </TableBody>
+            </Table>
+        </StyledPaper>
+    );
+};
+
+export default ReceiptDetail;

--- a/src/pages/orderPages/OrderDetailPage.tsx
+++ b/src/pages/orderPages/OrderDetailPage.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
 import styled from 'styled-components';
-import { Box, Container, Grid, Paper, Table, TableBody, TableCell, TableRow, Typography } from '@mui/material';
+import { Box, Container, Grid, Paper, Table, TableBody, TableCell, TableRow, Typography, Button } from '@mui/material';
 import { getOrderHandler } from '../../store/auth-action';
 import { getFormattedDate, getFormattedTime } from '../../util/dateUtil';
 import axiosUtils from '../../uitls/axiosUtils';
@@ -84,6 +84,10 @@ const OrderDetailPage: React.FC = () => {
     navigate(`/article/detail/${orderDetailResponse.articleApiId}`);
   };
 
+  const handleOpenReceiptDetail = () => {
+    window.open(`/article/${articleApiId}/order/${orderApiId}/${orderDetailResponse.receiptApiId}`, '_blank');
+  };
+
   const time = getFormattedDate(orderDetailResponse.date) + getFormattedTime(orderDetailResponse.date);
 
   return (
@@ -149,6 +153,20 @@ const OrderDetailPage: React.FC = () => {
               <TableRow>
                 <StyledTableCell variant="head">주문자 이름</StyledTableCell>
                 <TableCell>{orderDetailResponse.consumerName}</TableCell>
+              </TableRow>
+              <TableRow>
+                <StyledTableCell variant="head">영수증 상세</StyledTableCell>
+                <TableCell>
+                  <Button
+                      variant="outlined"
+                      color="primary"
+                      onClick={handleOpenReceiptDetail}
+                      onMouseEnter={handleMouseEnter}
+                      onMouseLeave={handleMouseLeave}
+                  >
+                    영수증 보기
+                  </Button>
+                </TableCell>
               </TableRow>
             </TableBody>
           </Table>

--- a/src/router/UserRouter.tsx
+++ b/src/router/UserRouter.tsx
@@ -32,6 +32,7 @@ import ReviewForm from '../components/user/ReviewForm.tsx';
 import OrderForm from '../components/user/OrderForm.tsx';
 import React from 'react';
 import OauthSignUpForm from '../components/auth/OauthSignUpForm.tsx';
+import ReceiptDetail from "../components/payment/ReceiptDetail.tsx";
 
 const OauthRedirect = React.lazy(
     () => import("../components/auth/OauthRedirect.tsx")
@@ -131,6 +132,8 @@ const UserRouter = () => {
       <Route path="/*" element={<Error404Page />} />
 
       <Route path="/oauth2-redirect" element={<OauthRedirect />} />
+
+      <Route path="/article/:articleApiId/order/:orderApiId/:receiptApiId" element={<ReceiptDetail />} />
 
     </Routes>
   );

--- a/src/types/order.ts
+++ b/src/types/order.ts
@@ -11,6 +11,7 @@ interface OrderDetailResponse {
   date: string;
   orderStatus: OrderStatus;
   amount: number;
+  receiptApiId: string;
 }
 interface OrderResponse {
   orderApiId: string;

--- a/src/types/receipt.ts
+++ b/src/types/receipt.ts
@@ -1,0 +1,36 @@
+
+interface Receipt {
+    mid: string;             // 가맹점 ID. 고유 식별자
+    version: string;         // API 버전
+    paymentKey: string;      // 결제 키. 결제 식별자
+    orderId: string;         // 주문 ID. Toss API 호출 키
+    orderName: string;       // 주문 이름
+    currency: string;        // 화폐 단위
+    method: string;          // 결제 방식
+    totalAmount: string;     // 총 결제 금액
+    balanceAmount: string;   // 잔액. 결제 후 남은 금액
+    suppliedAmount: string;  // 공급 가격. 부가세를 제외한 실제 상품/서비스의 가격
+    vat: string;             // 부가세
+    status: string;          // 결제 상태
+    requestedAt: string;     // 결제 요청 시각
+    approvedAt: string;      // 결제 승인 시각
+    useEscrow: string;       // 에스크로 사용 여부
+    cultureExpense: string;  // 문화비 지출 여부
+    card: ReceiptCard;       // 카드 결제 내역
+    type: string;            // 결제 유형
+}
+
+interface ReceiptCard {
+    company: string;         // 회사명
+    number: string;          // 카드번호
+    installmentPlanMonths: string;  // 할부 개월
+    isInterestFree: string;
+    approveNo: string;       // 승인번호
+    useCardPoint: string;    // 카드 포인트 사용 여부
+    cardType: string;        // 카드 타입
+    ownerType: string;       // 소유자 타입
+    acquireStatus: string;   // 승인 상태
+    receiptUrl: string;      // 영수증 URL
+}
+
+export { Receipt, ReceiptCard };


### PR DESCRIPTION
<!--풀리퀘 스트 작성 -->
<!-- 네이밍 방법 [✨Feature] , [📝Docs], [♻️Refactor], [🐛Fix], [🎉Release],   [🏗️Build], [🛠️Project], [✅Test] [🎨Design] 넣고   -->

## ✅ 풀리퀘스트 체크 리스트
<!-- 풀리퀘 보내는 경우 확인할 사항 --> 
- [ ] 커밋 메세지 컨벤션 확인
- [ ] 기능 수정 시에 테스트 코드 수정확인
- [ ] 추가 문서, 설명이 필요한 경우 문서 추가 작성 확인
- [ ] 풀리퀘스트 네이밍 컨벤션 확인
- [ ] 이슈 연동 확인  

## 🔗 이슈 연동
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
<!-- 만약 이슈를 닫는 경우 close 부분 작성  -->
<!-- close #NN -->

Linked Issue Number :  #7 
close   #7 


## 📣 새로 생성된 기능을 설명
 - [ ] 주문 상세 페이지에서 해당 주문의 영수증 정보 조회 컴포넌트 추가
 - [ ] 주문 type 생성
 - [ ] order type에 receipt api id를 함께 받을 수 있도록 추가


## 💬 추가 확인 사항
<!-- 줄글, 리스트 형식 자유 -->
 - 백엔드 PR GJ-26 (https://github.com/yetJunior/guhaejojibsa-backend/pull/42) 과 세트입니다. 먼저 머지가 되어야 정상 작동됩니다.